### PR TITLE
BUGFIX: initialize logger with correct name

### DIFF
--- a/bin/tmpcleaner.py
+++ b/bin/tmpcleaner.py
@@ -78,7 +78,7 @@ def main():
     args = parser.parse_args()
 
     logging_args = {'console': not args.quiet}
-    lg = gdctmpcleaner.logger.init(name='tmpcleaner', **logging_args)
+    lg = gdctmpcleaner.logger.init(name='gdctmpcleaner', **logging_args)
 
     if args.verbose:
         lg.setLevel(logging.INFO)

--- a/gdctmpcleaner/logger/__init__.py
+++ b/gdctmpcleaner/logger/__init__.py
@@ -26,7 +26,6 @@ lg = None
 def init(name='', level=logging.WARN, syslog=True, console=True):
     global lg
 
-    logging.basicConfig()
     lg = logging.getLogger(name)
     lg.setLevel(level)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class PyTest(TestCommand):
 # Parameters for build
 params = {
     'name': 'tmpcleaner',
-    'version': '1.0.3',
+    'version': '1.0.4',
     'packages': [
         'gdctmpcleaner',
         'gdctmpcleaner.logger'

--- a/tmpcleaner.spec
+++ b/tmpcleaner.spec
@@ -1,5 +1,5 @@
 Name:		tmpcleaner
-Version:	1.0.3
+Version:	1.0.4
 Release:	1%{?dist}
 Source0:	tmpcleaner.tar.gz
 License:	BSD


### PR DESCRIPTION
Prevent error
No handlers could be found for logger "gdctmpcleaner"
And use correct handlers for log messages.