### PR TITLE
TRIVIAL: fix pidfile location in test

### DIFF
--- a/tests/tmpcleaner/test_tmpcleaner.py
+++ b/tests/tmpcleaner/test_tmpcleaner.py
@@ -111,7 +111,7 @@ class TestE2E(unittest.TestCase):
         """
 
         config = '''---
-pidfile: '/var/run/tmpcleaner-execution-log.pid'
+pidfile: 'tmpcleaner-execution-log.pid'
 path: '%s'
 
 definitions:


### PR DESCRIPTION
in mocked builds, /var/run is unaccessible for normal user