### PR TITLE
BUGFIX: don't allow to escape root path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class PyTest(TestCommand):
 # Parameters for build
 params = {
     'name': 'tmpcleaner',
-    'version': '1.0.8',
+    'version': '1.0.9',
     'packages': [
         'gdctmpcleaner',
         'gdctmpcleaner.logger'

--- a/tmpcleaner.spec
+++ b/tmpcleaner.spec
@@ -1,5 +1,5 @@
 Name:		tmpcleaner
-Version:	1.0.8
+Version:	1.0.9
 Release:	1%{?dist}
 Source0:	tmpcleaner.tar.gz
 License:	BSD


### PR DESCRIPTION
if .* filter is specified