### PR TITLE
BUGFIX: PAAS-1922 don't create File object twice

### DIFF
--- a/gdctmpcleaner/__init__.py
+++ b/gdctmpcleaner/__init__.py
@@ -150,7 +150,7 @@ class TmpCleaner(object):
                     deleted_a_kid = True
                 else:
                     if f_object.directory:
-                        dirs.append(file_path)
+                        dirs.append(f_object)
         except OSError as e:
             # Exceptions that may come from os.listdir()
             if e.errno == errno.ENOENT:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class PyTest(TestCommand):
 # Parameters for build
 params = {
     'name': 'tmpcleaner',
-    'version': '1.0.9',
+    'version': '1.0.10',
     'packages': [
         'gdctmpcleaner',
         'gdctmpcleaner.logger'

--- a/tmpcleaner.spec
+++ b/tmpcleaner.spec
@@ -1,5 +1,5 @@
 Name:		tmpcleaner
-Version:	1.0.9
+Version:	1.0.10
 Release:	1%{?dist}
 Source0:	tmpcleaner.tar.gz
 License:	BSD


### PR DESCRIPTION
Use the creation wrapped by try-except block to avoid failures
if the directory get's deleted before tmpcleaner reaches it.