### PR TITLE
BUGFIX: PAAS-1931 fix invalid statistics

### DIFF
--- a/gdctmpcleaner/__init__.py
+++ b/gdctmpcleaner/__init__.py
@@ -252,7 +252,8 @@ class TmpCleaner(object):
                 # Set removed flag manually in dry-run
                 file.removed = True
 
-        self.update_summary(file)
+        if file.removed:
+            self.update_summary(file)
         return file
 
     def update_summary(self, f_object):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class PyTest(TestCommand):
 # Parameters for build
 params = {
     'name': 'tmpcleaner',
-    'version': '1.0.10',
+    'version': '1.0.11',
     'packages': [
         'gdctmpcleaner',
         'gdctmpcleaner.logger'

--- a/tmpcleaner.spec
+++ b/tmpcleaner.spec
@@ -1,5 +1,5 @@
 Name:		tmpcleaner
-Version:	1.0.10
+Version:	1.0.11
 Release:	1%{?dist}
 Source0:	tmpcleaner.tar.gz
 License:	BSD


### PR DESCRIPTION
Update the statistics only in case of successful removal.
Before this fix, nonempty directories were counted multiple times
and files/dirs deleted by different tool than tmpcleaner were taken
into account too.